### PR TITLE
upgrade chart versions

### DIFF
--- a/charts/jenkins-x/jenkins-x-platform.yml
+++ b/charts/jenkins-x/jenkins-x-platform.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jenkins-x-platform
-version: 0.0.3877
+version: 2.0.4

--- a/charts/jenkins-x/prow.yml
+++ b/charts/jenkins-x/prow.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/prow
-version: 0.0.494
+version: 0.0.500

--- a/charts/stable/cert-manager.yml
+++ b/charts/stable/cert-manager.yml
@@ -1,2 +1,2 @@
-version: v0.6.0
 gitUrl: https://github.com/helm/charts/tree/master/stable/cert-manager
+version: v0.6.7

--- a/charts/stable/external-dns.yml
+++ b/charts/stable/external-dns.yml
@@ -1,2 +1,2 @@
-version: 1.5.2
 gitUrl: https://github.com/bitnami/charts/tree/master/bitnami/external-dns
+version: 1.7.3

--- a/charts/stable/grafana.yml
+++ b/charts/stable/grafana.yml
@@ -1,1 +1,1 @@
-version: 2.2.5
+version: 3.3.0

--- a/charts/stable/nginx-ingress.yml
+++ b/charts/stable/nginx-ingress.yml
@@ -1,2 +1,2 @@
-version: 1.3.1
 gitUrl: https://github.com/helm/charts/tree/master/stable/nginx-ingress
+version: 1.4.0


### PR DESCRIPTION
change `jenkins-x/jenkins-x-platform` to version `2.0.4`
change `jenkins-x/prow` to version `0.0.500`
change `stable/cert-manager` to version `v0.6.7`
change `stable/external-dns` to version `1.7.3`
change `stable/grafana` to version `3.3.0`
change `stable/nginx-ingress` to version `1.4.0`
